### PR TITLE
chore: wrap truncate/insert in a transaction.

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,4 +1,4 @@
 config-version: 2
 
 name: 'snowflake_timetravel_table'
-version: '0.0.3'
+version: '0.0.4'

--- a/integration_tests/tests/test_integration.py
+++ b/integration_tests/tests/test_integration.py
@@ -29,8 +29,10 @@ RUN_RESULTS_PATH = os.path.join(
         (
             "snowflake_timetravel_table_integration_tests_columns_no_change",
             (
+                "begin",
                 "truncate table",
                 "insert into",
+                "commit",
             ),
         ),
         (


### PR DESCRIPTION
Starting with release 0.21.0 of dbt(https://github.com/dbt-labs/dbt-core/pull/3510), transactions were turned off and autocommit has been turned on. 

This re-enables transactions for our custom materialization by wrapping truncate/insert in a begin/commit. 

The integration tests passed, also confirmed visually by viewing query history:
<img width="1680" alt="Screen Shot 2022-07-29 at 3 13 16 AM" src="https://user-images.githubusercontent.com/5018044/181646255-e8cc693a-bade-4853-880e-3cc780c05a0a.png">
